### PR TITLE
Simpler prefixing for canvas element

### DIFF
--- a/source/javascripts/all.js.coffee
+++ b/source/javascripts/all.js.coffee
@@ -123,17 +123,15 @@ $ ->
     transitionTime = duration
 
     # Set new scale and canvas position
-    window.Engine.canvas.css
-      "-webkit-transition": "all #{transitionTime}s #{window.Engine.transitionEasing}"
-      "-moz-transition":    "all #{transitionTime}s #{window.Engine.transitionEasing}"
-      "-o-transition":      "all #{transitionTime}s #{window.Engine.transitionEasing}"
-      "-ms-transition":     "all #{transitionTime}s #{window.Engine.transitionEasing}"
-      "transition":         "all #{transitionTime}s #{window.Engine.transitionEasing}"
-      "-webkit-transform": "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
-      "-moz-transform":    "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
-      "-o-transform":      "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
-      "-ms-transform":     "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
-      "transform":         "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
+    cs = window.Engine.canvas[0];
+
+    cs.style.webkitTransition =
+    cs.style.msTransition =
+    cs.style.transition = "all #{transitionTime}s #{window.Engine.transitionEasing}"
+
+    cs.style.webkitTransform =
+    cs.style.msTransform =
+    cs.style.transform = "scale3d(#{scale}, #{scale}, #{scale}) translate3d(#{x}px, #{y}px, #{z}px)"
 
     #
     # Debug logs


### PR DESCRIPTION
- You can drop the -o and -moz prefixes completely.
- Easier to edit in the future if the CSS is on one line only. Also saves some bytes :)
